### PR TITLE
Subhas | Added an auto-incrementing counter variable

### DIFF
--- a/calculate.py
+++ b/calculate.py
@@ -30,12 +30,14 @@ class CalculateCommand(sublime_plugin.TextCommand):
         self.dict['password'] = password
 
     def run(self, edit, **kwargs):
+        self.dict['i'] = 0
         for region in self.view.sel():
             try:
                 error = self.run_each(edit, region, **kwargs)
             except Exception as exception:
                 error = exception.message
 
+            self.dict['i'] = self.dict['i'] + 1
             if error:
                 sublime.status_message(error)
 


### PR DESCRIPTION
Hi, I've added a counter `i` which automatically increments for each selection when running the Calculate command. For example:

Selecting the below text on the left, and running Calculate would produce:

```
i                   =>          0
i                   =>          1
i                   =>          2
```

```
i+10                =>          10
i+10                =>          11
i+10                =>          12
```

```
(i+10)*100          =>          1000
(i+10)*100          =>          1100
(i+10)*100          =>          1200
```

etc.

This is very useful for me since I can now apply linearly increasing mathematical calculations. It doesn't affect any existing functionality, the existing Calculate plugin will run as it is, only people wanting a counter variable can simply use `i`.
