### PR TITLE
Resolve #11, add option to evaluate line when selection is empty

### DIFF
--- a/Example.sublime-keymap
+++ b/Example.sublime-keymap
@@ -1,6 +1,6 @@
 [
-    { "keys": ["ctrl+shift+="], "command": "calculate", "args": {"replace": false, "empty_as_line": true} },
-    { "keys": ["ctrl+shift+c"], "command": "calculate", "args": {"replace": true, "empty_as_line": true} },
+    { "keys": ["ctrl+shift+="], "command": "calculate", "args": {"replace": false} },
+    { "keys": ["ctrl+shift+c"], "command": "calculate", "args": {"replace": true} },
     { "keys": ["ctrl+up"], "command": "calculate_increment" },
     { "keys": ["ctrl+down"], "command": "calculate_decrement" },
     { "keys": ["ctrl+shift+alt+1"], "command": "calculate_count" }

--- a/Example.sublime-keymap
+++ b/Example.sublime-keymap
@@ -1,6 +1,6 @@
 [
-    { "keys": ["ctrl+shift+="], "command": "calculate", "args": {"replace": false} },
-    { "keys": ["ctrl+shift+c"], "command": "calculate", "args": {"replace": true} },
+    { "keys": ["ctrl+shift+="], "command": "calculate", "args": {"replace": false, "empty_as_line": true} },
+    { "keys": ["ctrl+shift+c"], "command": "calculate", "args": {"replace": true, "empty_as_line": true} },
     { "keys": ["ctrl+up"], "command": "calculate_increment" },
     { "keys": ["ctrl+down"], "command": "calculate_decrement" },
     { "keys": ["ctrl+shift+alt+1"], "command": "calculate_count" }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Calculate
 =========
 
-Select a formula and run `calculate` to evaluate it using python.  The result can be appended to the selection (`1+1` => `1+1 = 2`) or replace the selection (`1+1` => `2`).  Using the `replace: true` option replaces the selected text with the result.  If you have zero selections, you will be prompted for a formula, and the result will be inserted.  Using the `empty_as_line: true` option to alter this behavior and treat empty selections as operating on lines instead. 
+Select a formula and run `calculate` to evaluate it using python.  The result can be appended to the selection (`1+1` => `1+1 = 2`) or replace the selection (`1+1` => `2`).  Using the `replace: true` option replaces the selected text with the result.  Empty selections are treated as operating on lines, like most sublime commands.  When the line under the caret is not a formula, you will be prompted for one, and the result will be inserted.  
 
 Any function from `math` and `random` libraries can be used ([math][] and [random][] documentation).
 
@@ -36,7 +36,7 @@ Or:
 Commands
 --------
 
-* `calculate`: Calculates the selection(s), or prompts for a formula.  The `replace` argument (default: `false`) can be used to format the result (see above). The `empty_as_line` argument (default: `false`) alters the behavior to use the whole line as formula instead of prompting for it (see above). 
+* `calculate`: Calculates the selection(s), or prompts for a formula.  The `replace` argument (default: `false`) can be used to format the result (see above).  The `prompt` argument (default: `true`) controls whether to prompt for a formula or not (see above as well). 
 * `calculate_count`: Counts, adding 1 to the initial index, over each selection.
   - If the first selection is a number, it is used as the initial index.
   - Hexadecimal (`0xNNNN`) and octal (`0NNNN`) are matched, too.
@@ -54,8 +54,8 @@ Open your key bindings file and add the bindings you want.  For example:
 ###### Example.sublime-keymap
 ```json
 [
-    { "keys": ["ctrl+shift+="], "command": "calculate", "args": {"replace": false, "empty_as_line": true} },
-    { "keys": ["ctrl+shift+c"], "command": "calculate", "args": {"replace": true, "empty_as_line": true} },
+    { "keys": ["ctrl+shift+="], "command": "calculate", "args": {"replace": false} },
+    { "keys": ["ctrl+shift+c"], "command": "calculate", "args": {"replace": true} },
     { "keys": ["ctrl+up"], "command": "calculate_increment" },
     { "keys": ["ctrl+down"], "command": "calculate_decrement" },
     { "keys": ["ctrl+shift+alt+1"], "command": "calculate_count" }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Or:
 Commands
 --------
 
-* `calculate`: Calculates the selection(s), or prompts for a formula.  The `replace` argument (default: `false`) can be used to format the result (see above).  The `prompt` argument (default: `true`) controls whether to prompt for a formula or not (see above as well). 
+* `calculate`: Calculates the selection(s), or prompts for a formula.  The `replace` argument (default: `false`) can be used to format the result (see above).  The `prompt` argument (default: `true`) controls when to prompt for a formula, `true` for default behavior (see above), `false` for never and `"always"` whenever the selection is empty. 
 * `calculate_count`: Counts, adding 1 to the initial index, over each selection.
   - If the first selection is a number, it is used as the initial index.
   - Hexadecimal (`0xNNNN`) and octal (`0NNNN`) are matched, too.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Calculate
 =========
 
-Select a formula and run `calculate` to evaluate it using python.  The result can be appended to the selection (`1+1` => `1+1 = 2`) or replace the selection (`1+1` => `2`).  Using the `replace: true` option replaces the selected text with the result.  If you have zero selections, you will be prompted for a formula, and the result will be inserted.
+Select a formula and run `calculate` to evaluate it using python.  The result can be appended to the selection (`1+1` => `1+1 = 2`) or replace the selection (`1+1` => `2`).  Using the `replace: true` option replaces the selected text with the result.  If you have zero selections, you will be prompted for a formula, and the result will be inserted.  Using the `empty_as_line: true` option to alter this behavior and treat empty selections as operating on lines instead. 
 
 Any function from `math` and `random` libraries can be used ([math][] and [random][] documentation).
 
@@ -36,7 +36,7 @@ Or:
 Commands
 --------
 
-* `calculate`: Calculates the selection(s), or prompts for a formula.  The `replace` argument (default: `false`) can be used to format the result (see above).
+* `calculate`: Calculates the selection(s), or prompts for a formula.  The `replace` argument (default: `false`) can be used to format the result (see above). The `empty_as_line` argument (default: `false`) alters the behavior to use the whole line as formula instead of prompting for it (see above). 
 * `calculate_count`: Counts, adding 1 to the initial index, over each selection.
   - If the first selection is a number, it is used as the initial index.
   - Hexadecimal (`0xNNNN`) and octal (`0NNNN`) are matched, too.
@@ -54,8 +54,8 @@ Open your key bindings file and add the bindings you want.  For example:
 ###### Example.sublime-keymap
 ```json
 [
-    { "keys": ["ctrl+shift+="], "command": "calculate", "args": {"replace": false} },
-    { "keys": ["ctrl+shift+c"], "command": "calculate", "args": {"replace": true} },
+    { "keys": ["ctrl+shift+="], "command": "calculate", "args": {"replace": false, "empty_as_line": true} },
+    { "keys": ["ctrl+shift+c"], "command": "calculate", "args": {"replace": true, "empty_as_line": true} },
     { "keys": ["ctrl+up"], "command": "calculate_increment" },
     { "keys": ["ctrl+down"], "command": "calculate_decrement" },
     { "keys": ["ctrl+shift+alt+1"], "command": "calculate_count" }

--- a/calculate.py
+++ b/calculate.py
@@ -31,7 +31,7 @@ class CalculateCommand(sublime_plugin.TextCommand):
 
     def run(self, edit, **kwargs):
         self.dict['i'] = 0
-        if len(self.view.sel()) == 1 and not self.view.sel()[0]:
+        if not kwargs.get('empty_as_line', False) and len(self.view.sel()) == 1 and not self.view.sel()[0]:
             return self.get_formula()
         for region in self.view.sel():
             try:
@@ -58,13 +58,26 @@ class CalculateCommand(sublime_plugin.TextCommand):
 
         return result
 
-    def run_each(self, edit, region, replace=False):
+    def run_each(self, edit, region, replace=False, empty_as_line=False):
         if not region.empty():
             formula = self.view.substr(region)
             value = self.calculate(formula)
             if not replace:
                 value = "%s = %s" % (formula, value)
             self.view.replace(edit, region, value)
+        elif empty_as_line:
+            line = self.view.line(region.a)
+            formula = self.view.substr(line)
+
+            value = self.calculate(formula)
+            self.view.sel().subtract(region)
+            if not replace:
+                value = " = %s" % (value)
+                self.view.replace(edit, sublime.Region(line.b, line.b), value)
+            else:
+                self.view.replace(edit, line, value)
+            line = self.view.line(line.a)
+            self.view.sel().add(sublime.Region(line.b, line.b))
 
     def get_formula(self):
         self.view.window().show_input_panel('Calculate:', '', self.on_calculate, None, None)

--- a/calculate.py
+++ b/calculate.py
@@ -63,6 +63,8 @@ class CalculateCommand(sublime_plugin.TextCommand):
             if not replace:
                 value = "%s = %s" % (formula, value)
             self.view.replace(edit, region, value)
+        elif prompt == 'always':
+            self.get_formula()
         else:
             line = self.view.line(region.a)
             formula = self.view.substr(line)


### PR DESCRIPTION
It is very useful if empty selections can be treated as operating on lines, like many built-in sublime commands. This PR adds this functionality under an option and keeps previous behaviors by default. 

Any new users are recommended to turn this option on by default in key bindings (subject to discussion). 