### PR TITLE
Add more settings options and add run commands for each regions.

### DIFF
--- a/Calculate.sublime-settings
+++ b/Calculate.sublime-settings
@@ -2,4 +2,11 @@
   // Enable "copy on calculate" behaviour. After a calculation, the result will
   // be put into the clipboard.
   // "copy_to_clipboard": true,
+  // Customize the calculation symbol.
+  // The `index_symbol` presents the index of selections.
+  // The `total_count_symbol` presents the total count of regions.
+  // The `region_symbol` presents each region's value.
+  // "index_symbol": "i",
+  // "total_count_symbol": "n",
+  // "region_symbol": "x",
 }

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,11 +4,19 @@
         "command": "calculate"
     },
     {
+        "caption": "Calculate: With Replace",
+        "command": "calculate_replace"
+    },
+    {
+        "caption": "Calculate: Run Command for each regions",
+        "command": "calculate_each_region"
+    },
+    {
         "caption": "Calculate: Average selections",
         "command": "calculate_mean"
     },
     {
-        "caption": "Calculate: Standard Deviation of selections",
+        "caption": "Calculate: Standard deviation of selections",
         "command": "calculate_std"
     },
     {
@@ -26,5 +34,9 @@
     {
         "caption": "Calculate: Count",
         "command": "calculate_count"
-    }
+    },
+    {
+        "caption": "Calculate: Open Settings",
+        "command": "open_settings"
+    },
 ]

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -4,11 +4,11 @@
         "command": "calculate"
     },
     {
-        "caption": "Calculate: With Replace",
+        "caption": "Calculate: With replace",
         "command": "calculate_replace"
     },
     {
-        "caption": "Calculate: Run Command for each regions",
+        "caption": "Calculate: Run command for each regions",
         "command": "calculate_each_region"
     },
     {

--- a/Default.sublime-commands
+++ b/Default.sublime-commands
@@ -34,9 +34,5 @@
     {
         "caption": "Calculate: Count",
         "command": "calculate_count"
-    },
-    {
-        "caption": "Calculate: Open Settings",
-        "command": "open_settings"
-    },
+    }
 ]

--- a/README.md
+++ b/README.md
@@ -7,12 +7,42 @@ Because this plugin uses python to evaluate the selection, we cannot support cou
 Any function from `math` and `random` libraries can be used ([math][] and [random][] documentation).
 
 You can generate passwords using `pwd(len)` (or `password(len)`).
-You can calculate averages (mean) using `avg([values])` (or `average([values])`).
-If you need to use a counter, you can use the `i` variable. Every selection will increase the counter, and it starts at 0.
 
-    i  =>  0        i*i  =>  0        (i+1)*10  =>  10
-    i  =>  1        i*i  =>  1        (i+1)*10  =>  20
-    i  =>  2        i*i  =>  4        (i+1)*10  =>  30
+Examples:
+
+```
+min(1,2,4)+max(9.8,9.11) = 10.8
+round(1.23)+int(3.14)+ceil(3.6)+floor(3.4) = 11
+oct(10) = 0o12
+seed(42) = None
+uniform(0,1)+randint(1,10) = 1.6394267984578836
+choice(['a','b','c']) = c
+sqrt(2)+pow(2,2) = 5.414213562373095
+pi+e = 5.859874482048838
+cos(pi/4)-sqrt(2)/2 = 0
+pwd(16) = RPOIvGrv5iFlbCBF
+```
+
+You can calculate averages (mean) using `avg([values])` (or `average([values])`).
+If you need to use a counter, you can use the `i` variable. Every selection will increase the counter, and it starts at 0. The `n` variable presents the total regions you've selected.
+
+```
+    i  =>  0        n-i-1 => 2        i*i  =>  0        (i+1)*10  =>  10
+    i  =>  1        n-i-1 => 1        i*i  =>  1        (i+1)*10  =>  20
+    i  =>  2        n-i-1 => 0        i*i  =>  4        (i+1)*10  =>  30
+```
+
+By typing command `Calculate: Run command for each regions`, you can run a python eval command for each regions, the region values are marked as `x`. 
+
+For instance, type `x+1` will do an increment, and `x-1` is a decrement.
+
+```
+    x+1           x**x            x-n-1         x+1
+    1 => 2        1 => 1          1 => -4       1+1 => 3
+    2 => 3        2 => 4          2 => -3       2+1 => 4
+    3 => 4        3 => 27         3 => -2       3+1 => 5
+    4 => 5        4 => 256        4 => -1       4+1 => 6
+```
 
 There is also a `calculate_count` command, used to count from 1 (or another index, see below) and incrementing at every cursor.
 
@@ -37,6 +67,7 @@ Or:
 ## Commands
 
 - `calculate`: Calculates the selection(s), or prompts for a formula. The `replace` argument (default: `false`) can be used to format the result (see above). The `prompt` argument (default: `true`) controls when to prompt for a formula, `true` for default behavior (see above), `false` for never and `"always"` whenever the selection is empty.
+- `calculate_replace`: `calculate` command with replacement.
 - `calculate_count`: Counts, adding 1 to the initial index, over each selection.
   - If the first selection is a number, it is used as the initial index.
   - Hexadecimal (`0xNNNN`) and octal (`0NNNN`) are matched, too.
@@ -45,6 +76,14 @@ Or:
 - `calculate_add`: Add all the selected numbers and put the summation in the last empty cursor.
 - `calculate_increment`: Increment the selected numbers by 1 (or number that the cursor is on).
 - `calculate_decrement`: Decrement the selected numbers by 1 (or number that the cursor is on).
+- `calculate_each_region`: Calculate each regions according to the command, the regions value are marked as `x`.
+
+## Options & Settings
+
+- `copy_to_clipboard`: Default is `False`. When enabled, the result will be put into the clipboard after calculation.
+- `index_symbol`: Default is `'i'`. It presents the index of selections.
+- `total_count_symbol`: Default is `'n'`. It presents the total count of regions.
+- `region_symbol`: Default is `'x'`. It presents each region's value.
 
 ## Keybindings
 

--- a/calculate.py
+++ b/calculate.py
@@ -386,11 +386,13 @@ class ApplyCalculationCommand(CalculateCommand):
         selections = self.view.sel()
         for region in selections:
             try:
-                formula = self.view.substr(region)
-                self.dict[self.region_symbol] = eval(formula, self.dict, {})
+                if not region.empty():
+                    formula = self.view.substr(region)
+                    self.dict[self.region_symbol] = eval(formula, self.dict, {})
+                else:
+                    self.dict[self.region_symbol] = 0
                 result = eval(command, self.dict, {})
                 self.view.replace(edit, region, str(result))
-
             except Exception as exception:
                 error = str(exception)
                 self.view.show_popup(error)

--- a/calculate.py
+++ b/calculate.py
@@ -9,7 +9,7 @@ import sublime_plugin
 import json
 
 def load_settings():
-    return sublime.load_settings("SublimeCalculate.sublime-settings")
+    return sublime.load_settings("Calculate.sublime-settings")
 
 def mean(numbers, *more):
     if more:
@@ -53,11 +53,6 @@ class SelectionListener(sublime_plugin.EventListener):
             return
         numbers = [atof(view.substr(sel)) for sel in number_selections]
         sublime.status_message("Sum: {:n}\tAverage: {:n}".format(sum(numbers), mean(numbers)))
-
-# add replace command for convenience
-class CalculateReplaceCommand(CalculateCommand):
-    def run(self, edit):
-        self.view.run_command("calculate", {"replace": True})
 
 class CalculateCommand(sublime_plugin.TextCommand):
     def __init__(self, *args, **kwargs):
@@ -191,6 +186,10 @@ class CalculateCommand(sublime_plugin.TextCommand):
         value = self.calculate(formula)
         self.view.run_command('insert_snippet', {'contents': '${0:%s}' % value})
 
+# add replace command for convenience
+class CalculateReplaceCommand(CalculateCommand):
+    def run(self, edit):
+        self.view.run_command("calculate", {"replace": True})
 
 class CalculateCountCommand(sublime_plugin.TextCommand):
     def run(self, edit, index=1):
@@ -397,18 +396,3 @@ class ApplyCalculationCommand(CalculateCommand):
                 self.view.show_popup(error)
 
             self.dict[self.index_symbol] = self.dict[self.index_symbol] + 1
-
-
-class OpenSettingsCommand(sublime_plugin.WindowCommand):
-    def run(self):
-        setting_path = os.path.join(sublime.packages_path(), 'User', 'SublimeCalculate.sublime-settings')
-        if not os.path.exists(setting_path):
-            default_settings = {
-                "copy_to_clipboard": False,
-                "index_symbol": "i",
-                "total_count_symbol": "n",
-                "region_symbol": "x",
-            }
-            with open(setting_path, 'w') as f:
-                json.dump(default_settings, f, indent=4)
-        self.window.run_command("open_file", {"file": setting_path})


### PR DESCRIPTION
This PR do several things:
* Add `n` as the total regions count. This feature is quite useful. For example, `i` in 10 regions will produce 0\~9, `n-i-1` will produce 9\~0.
* Allow users enter commands to calculate each regions. When typing `Calculate: Run command for each regions`, a text field will pop up and users can enter math equations like `x+1`, with region value marked as `x`. For example, `x+1` will do an increment.
* Add settings to allow users change symbols mentioned above: `i`, `n`, `x`.
* Add command `Calculate: With Replace` because I personally prefer replacement but I'm tied of typing `view.run_command("calculate", {"replace": True})` every time. So I added the command for convience, if you don't mind :)
